### PR TITLE
图片本地上传后，允许用户填写图注

### DIFF
--- a/plugins/image/image.js
+++ b/plugins/image/image.js
@@ -16,6 +16,7 @@ KindEditor.plugin('image', function(K) {
 		imageTabIndex = K.undef(self.imageTabIndex, 0),
 		imgPath = self.pluginsPath + 'image/images/',
 		extraParams = K.undef(self.extraFileUploadParams, {}),
+		fillDescAfterUploadImage = K.undef(self.fillDescAfterUploadImage, false),
 		lang = self.lang(name + '.');
 
 	self.plugin.imageDialog = function(options) {
@@ -189,12 +190,15 @@ KindEditor.plugin('image', function(K) {
 					if (formatUploadUrl) {
 						url = K.formatUrl(url, 'absolute');
 					}
-					// clickFn.call(self, url, '', '', '', 0, '');
-					K(".ke-dialog-row #remoteUrl").val(url);
-					K(".ke-tabs-li")[0].click();
-					K(".ke-refresh-btn").click();
 					if (self.afterUpload) {
 						self.afterUpload.call(self, url);
+					}
+					if (!fillDescAfterUploadImage) {
+						clickFn.call(self, url, '', '', '', 0, '');	
+					} else {
+						K(".ke-dialog-row #remoteUrl").val(url);
+						K(".ke-tabs-li")[0].click();
+						K(".ke-refresh-btn").click();
 					}
 				} else {
 					alert(data.message);


### PR DESCRIPTION
用户上传本地图片后，来不及填写图注，弹出窗口就关闭了。使用过程中不方便，修改为用户上传本地图片后，自动跳到网络图片选项，此处可以修改图注、尺寸。这种做法和ckeditor等是一致的。希望予以考虑，能极大方便用户的操作。
