### PR TITLE
Implements tabindex for V4

### DIFF
--- a/kindeditor.js
+++ b/kindeditor.js
@@ -3615,6 +3615,9 @@ _extend(KEdit, KWidget, {
 			iframeSrc = _IE ? ' src="javascript:void(function(){' + encodeURIComponent(srcScript) + '}())"' : '';
 		self.iframe = K('<iframe class="ke-edit-iframe" hidefocus="true" frameborder="0"' + iframeSrc + '></iframe>').css('width', '100%');
 		self.textarea = K('<textarea class="ke-edit-textarea" hidefocus="true"></textarea>').css('width', '100%');
+		self.tabIndex = isNaN(parseInt(options.tabIndex)) ? self.srcElement.attr("tabindex") : parseInt(options.tabIndex);
+		self.iframe.attr("tabindex", self.tabIndex);
+		self.textarea.attr("tabindex", self.tabIndex);
 		if (self.width) {
 			self.setWidth(self.width);
 		}


### PR DESCRIPTION
User could add a option named "tabindex", or the tabindex will be same as the original textarea.
