### PR TITLE
Safari iframe scrollbar hack

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -296,10 +296,23 @@ _extend(KEdit, KWidget, {
 		if (bool === undefined ? !self.designMode : bool) {
 			if (!self.designMode) {
 				val = self.html();
+
 				self.designMode = true;
-				self.html(val);
 				self.textarea.hide();
-				self.iframe.show();
+
+				self.html(val);
+
+				// cache
+				var iframe = self.iframe;
+				var height = _removeUnit(self.height);
+
+				iframe.height(height - 2);
+				iframe.show();
+
+				// safari iframe scrollbar hack
+				setTimeout(function() {
+					iframe.height(height);
+				}, 0);
 			}
 		} else {
 			if (self.designMode) {

--- a/src/main.js
+++ b/src/main.js
@@ -1505,6 +1505,9 @@ _plugin('core', function(K) {
 			} else {
 				cmd.range.selectNodeContents(div[0]);
 				cmd.select();
+
+				div[0].tabIndex = -1;
+				div[0].focus();
 			}
 			setTimeout(function() {
 				movePastedData();


### PR DESCRIPTION
Mac Safari 浏览器有个BUG， iframe 在隐藏后，再显示无法再滚动；
hack 处理掉，重设高度即可