### PR TITLE
修复了自动高度的时候全屏没有滚动条的情况

### DIFF
--- a/plugins/autoheight/autoheight.js
+++ b/plugins/autoheight/autoheight.js
@@ -24,6 +24,9 @@ KindEditor.plugin('autoheight', function(K) {
 	}
 
 	function resetHeight() {
+		if(self.fullscreenMode){
+			return;
+		}
 		var edit = self.edit;
 		var body = edit.doc.body;
 		edit.iframe.height(minHeight);
@@ -34,7 +37,9 @@ KindEditor.plugin('autoheight', function(K) {
 		minHeight = K.removeUnit(self.height);
 
 		self.edit.afterChange(resetHeight);
-		hideScroll();
+		if(!self.fullscreenMode){
+			hideScroll();
+		}
 		resetHeight();
 	}
 


### PR DESCRIPTION
经过本人测试在开启了autoHeightMode以后,

再开启全屏,然后高度仍会自动增高,并且不显示滚动条,

全屏模式下无法查看超出屏幕的内容部分,

故做了一下fix,希望官方通过～