### PR TITLE
Some KindEditor problems solved by Coremail

### DIFF
--- a/plugins/autoheight/autoheight.js
+++ b/plugins/autoheight/autoheight.js
@@ -19,7 +19,7 @@ KindEditor.plugin('autoheight', function(K) {
 	function hideScroll() {
 		var edit = self.edit;
 		var body = edit.doc.body;
-		edit.iframe[0].scroll = 'no';
+		edit.htmlIframe[0].scroll = 'no';
 		body.style.overflowY = 'hidden';
 	}
 
@@ -29,7 +29,7 @@ KindEditor.plugin('autoheight', function(K) {
 		}
 		var edit = self.edit;
 		var body = edit.doc.body;
-		edit.iframe.height(minHeight);
+		edit.htmlIframe.height(minHeight);
 		self.resize(null, Math.max((K.IE ? body.scrollHeight : body.offsetHeight) + 76, minHeight));
 	}
 

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -277,10 +277,10 @@ _extend(KCmd, {
 			sel.removeAllRanges();
 			sel.addRange(rng);
 			// Bugfix: https://github.com/kindsoft/kindeditor/issues/54
-			if (doc !== document) {
+			/*if (doc !== document) {
 				var pos = K(rng.endContainer).pos();
 				win.scrollTo(pos.x, pos.y);
-			}
+			}*/
 		}
 		win.focus();
 		return self;

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -160,9 +160,10 @@ function _mergeWrapper(a, b) {
 //wrap and merge a node
 function _wrapNode(knode, wrapper) {
 	wrapper = wrapper.clone(true);
-	//node为text node时
-	if (knode.type == 3) {
-		_getInnerNode(wrapper).append(knode.clone(false));
+	// wrap node when it is a text node or an anchor element
+	if (knode.type == 3 || knode.name === 'a') {
+		// clone all children with event when the node is an anchor element
+		_getInnerNode(wrapper).append(knode.clone(knode.name === 'a'));
 		knode.replaceWith(wrapper);
 		return wrapper;
 	}
@@ -326,6 +327,11 @@ _extend(KCmd, {
 					var parent;
 					while ((parent = knode.parent()) && parent.isStyle() && parent.children().length == 1) {
 						knode = parent;
+					}
+					// replace whole anchor elements when the node is wrapped by an `a` tag
+					while (parent.name === 'a') {
+						knode = parent;
+						parent = knode.parent();
 					}
 					_wrapNode(knode, wrapper);
 				}

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -381,6 +381,11 @@ _extend(KCmd, {
 						knode = parent;
 						parent = knode.parent();
 					}
+					// set inherited color for anchor elements when they are set with forecolor
+					if (wrapper.attr('class') === 'ke-content-forecolor' && knode.name == 'a') {
+						// IE8 can not set 'inherit' for the color attribute
+						knode.css('color', wrapper[0].style.color);
+					}
 					_wrapNode(knode, wrapper);
 				}
 			}
@@ -708,7 +713,8 @@ _extend(KCmd, {
 		});
 	},
 	forecolor : function(val) {
-		return this.wrap('<span style="color:' + val + ';"></span>').select();
+		// add className for anchor elements
+		return this.wrap('<span class="ke-content-forecolor" style="color:' + val + ';"></span>').select();
 		// return this.toggle('<span style="color:' + val + ';"></span>', {
 		// 	span : '.color=' + val,
 		// 	font : 'color'

--- a/src/core.js
+++ b/src/core.js
@@ -19,8 +19,8 @@ var _VERSION = '${VERSION}',
 	_IOS = /ipad|iphone|ipod/.test(_ua),
 	_QUIRKS = document.compatMode != 'CSS1Compat',
 	_IERANGE = !window.getSelection,
-	_matches = /(?:msie|firefox|webkit|opera)[\/:\s](\d+)/.exec(_ua),
-	_V = _matches ? _matches[1] : '0',
+	_matches = /(?:msie|firefox|webkit|opera)[\/:\s](\d+)|trident\/.*rv:([0-9]+)/.exec(_ua),
+	_V = _matches ? (_matches[1] ? _matches[1] : _matches[2]) : '0',
 	_TIME = new Date().getTime();
 
 function _isArray(val) {

--- a/src/html.js
+++ b/src/html.js
@@ -170,7 +170,7 @@ function _formatHtml(html, htmlTags, urlType, wellFormatted, indentChar) {
 			html = html.replace(/(<(?:style|style\s[^>]*)>)([\s\S]*?)(<\/style>)/ig, '');
 		}
 	}
-	var re = /(\s*)<(\/)?([\w\-:]+)((?:\s+|(?:\s+[\w\-:]+)|(?:\s+[\w\-:]+=[^\s"'<>]+)|(?:\s+[\w\-:"]+="[^"]*")|(?:\s+[\w\-:"]+='[^']*'))*)(\/)?>(\s*)/g;
+	var re = /([ \f\n\r\t\v]*)<(\/)?([\w\-:]+)((?:[ \f\n\r\t\v]+|(?:[ \f\n\r\t\v]+[\w\-:]+)|(?:[ \f\n\r\t\v]+[\w\-:]+=[^ \f\n\r\t\v"'<>]+)|(?:[ \f\n\r\t\v]+[\w\-:"]+="[^"]*")|(?:[ \f\n\r\t\v]+[\w\-:"]+='[^']*'))*)(\/)?>([ \f\n\r\t\v]*)/g;
 	var tagStack = [];
 	html = html.replace(re, function($0, $1, $2, $3, $4, $5, $6) {
 		var full = $0,

--- a/src/html.js
+++ b/src/html.js
@@ -134,8 +134,22 @@ function _formatHtml(html, htmlTags, urlType, wellFormatted, indentChar) {
 	});
 	// <br/></p> to </p>
 	html = html.replace(/<(?:br|br\s[^>]*)\s*\/?>\s*<\/p>/ig, '</p>');
-	// <p></p> to <p><br /></p>
-	html = html.replace(/(<(?:p|p\s[^>]*)>)\s*(<\/p>)/ig, '$1<br />$2');
+	// IE8 get selection will work wrong when pointing to `p` elements, while they are followed by `br` elements
+	if (_IERANGE) {
+		// ^<br /> to <p></p>
+		// </p><br /> to </p><p></p>
+		var regex = /((?:<\/p>)|^\s*)<(?:br|br\s[^>]*)\s*\/?>/ig;
+		while (regex.test(html)) {
+			// IE8 need &nbsp; to occupy a position
+			html = html.replace(regex, '$1<p>&nbsp;</p>');
+			// reset regex
+			regex.lastIndex = 0;
+		}
+	} else {
+		// under IE8, <p><br /></p> will create two single lines
+		// <p></p> to <p><br /></p>
+		html = html.replace(/(<(?:p|p\s[^>]*)>)\s*(<\/p>)/ig, '$1<br />$2');
+	}
 	// empty char
 	html = html.replace(/\u200B/g, '');
 	// &copy;

--- a/src/html.js
+++ b/src/html.js
@@ -322,6 +322,13 @@ function _formatHtml(html, htmlTags, urlType, wellFormatted, indentChar) {
 	html = html.replace(/\n\s*\n/g, '\n');
 	// 删除临时标签
 	html = html.replace(/<span id="__kindeditor_pre_newline__">\n/g, '\n');
+	// clear none border for IE
+	html = html.replace(/<(?:td)[^>]*>/ig, function(full) {
+		if (/<td[^>]*>/ig.test(full)) {
+			full = full.replace(/border:\s*0px black;/ig, '');
+		}
+		return full;
+	});
 	return _trim(html);
 }
 // 清理MS Word专用标签
@@ -334,6 +341,9 @@ function _clearMsWord(html, htmlTags) {
 		.replace(/<o:[^>]+>[\s\S]*?<\/o:[^>]+>/ig, '')
 		.replace(/<xml>[\s\S]*?<\/xml>/ig, '')
 		.replace(/<(?:table|td)[^>]*>/ig, function(full) {
+			if (/<table[^>]*>/ig.test(full)) {
+				full = full.replace(/border=['"]?\d?['"]?/ig, 'border="1"');
+			}
 			return full.replace(/border-bottom:([#\w\s]+)/ig, 'border:$1');
 		});
 	return _formatHtml(html, htmlTags);

--- a/src/main.js
+++ b/src/main.js
@@ -1422,6 +1422,10 @@ _plugin('core', function(K) {
 		var doc = self.edit.doc, cmd, bookmark, div,
 			cls = '__kindeditor_paste__', pasting = false;
 		function movePastedData() {
+			if (_IERANGE && /^<p>(.*)?<\/p>$/gi.test(div[0].innerHTML)) {
+				// IE8: if copy a paragraph, the html content should be programatically converted into a span element
+				div[0].innerHTML = div[0].innerHTML.replace(/^<p>(.*)?<\/p>$/gi, '<span style="white-space:normal">$1</span>');
+			}
 			cmd.range.moveToBookmark(bookmark);
 			cmd.select();
 			if (_WEBKIT) {
@@ -1500,15 +1504,18 @@ _plugin('core', function(K) {
 			});
 			K(doc.body).append(div);
 			if (_IE) {
-				var rng = cmd.range.get(true);
-				rng.moveToElementText(div[0]);
-				rng.select();
-				rng.execCommand('paste');
-				e.preventDefault();
+				try {
+					var rng = cmd.range.get(true);
+					rng.moveToElementText(div[0]);
+					rng.select();
+					rng.execCommand('paste');
+					e.preventDefault();
+				} catch (e) {
+					return false;
+				}
 			} else {
 				cmd.range.selectNodeContents(div[0]);
 				cmd.select();
-
 				div[0].tabIndex = -1;
 				div[0].focus();
 			}

--- a/src/main.js
+++ b/src/main.js
@@ -117,7 +117,7 @@ function _bindContextmenuEvent() {
 		});
 		if (items.length > 0) {
 			e.preventDefault();
-			var pos = K(self.edit.iframe).pos(),
+			var pos = K(self.edit.htmlIframe).pos(),
 				menu = _menu({
 					x : pos.x + e.clientX,
 					y : pos.y + e.clientY,
@@ -1001,6 +1001,9 @@ KEditor.prototype = {
 		K(doc.body).css('background-color', '#FFF');
 		iframe[0].contentWindow.focus();
 		return self;
+	},
+	getTextarea : function() {
+		return this.edit.textarea[0];
 	}
 };
 

--- a/src/range.js
+++ b/src/range.js
@@ -173,6 +173,11 @@ function _getStartEnd(rng, isStart) {
 		var node = nodes[i];
 		cmp = testRange.compareEndPoints('StartToStart', pointRange);
 		if (cmp === 0) {
+			// if cmp is zero, and the node is an anchor element, then set start to their first child
+			var nodeName = node.nodeName.toLowerCase();
+			if (nodeName === 'a') {
+				return {node: node.childNodes[0], offset: 0};
+			}
 			return {node: node.parentNode, offset: i};
 		}
 		if (node.nodeType == 1) {

--- a/src/range.js
+++ b/src/range.js
@@ -164,6 +164,10 @@ function _getStartEnd(rng, isStart) {
 	var parent = pointRange.parentElement(),
 		nodes = parent.childNodes;
 	if (nodes.length === 0) {
+		// under IE8, if a paragraph is empty, it still exist
+		if (parent.nodeName.toLowerCase() === 'p' && (parent.innerHTML === '' || parent.innerHTML === '&nbsp;')) {
+			return {node: parent, offset: 0};
+		}
 		return {node: parent.parentNode, offset: K(parent).index()};
 	}
 	var startNode = doc, startPos = 0, cmp = -1;
@@ -223,11 +227,14 @@ function _getStartEnd(rng, isStart) {
 	testRange.setEndPoint('StartToEnd', pointRange);
 	startPos -= testRange.text.replace(/\r\n|\n|\r/g, '').length;
 	// [textNode1][textNode2]ab|cd
-	if (cmp > 0 && startNode.nodeType == 3) {
-		var prevNode = startNode.previousSibling;
-		while (prevNode && prevNode.nodeType == 3) {
-			startPos -= prevNode.nodeValue.length;
-			prevNode = prevNode.previousSibling;
+	if (startNode.nodeType == 3) {
+		// when the startPos is bigger than current startNode value length, it should calculate the position again
+		if (cmp > 0 || (cmp < 0 && startPos > startNode.nodeValue.length)) {
+			var prevNode = startNode.previousSibling;
+			while (prevNode && prevNode.nodeType == 3) {
+				startPos -= prevNode.nodeValue.length;
+				prevNode = prevNode.previousSibling;
+			}
 		}
 	}
 	return {node: startNode, offset: startPos};


### PR DESCRIPTION
1. Move textarea of text mode into Iframe, to solve the performance problem when using Sogou input under IE8.
2. When wrapping anchor elments, some spefic format like _italic_ or **strong** should be wrapped around the whole anchor element rather than the text node inside it.
3. Support version number of IE11.
4. Fix range selection problems under IE or Firefox.
5. Some problems under IE8 including pasting.
6. Using the class name `ke-content-forecolor` to support setting custom color for anchors.